### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jonaslejon/ct-monitor/security/code-scanning/1](https://github.com/jonaslejon/ct-monitor/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the provided workflow, it primarily involves checking out the code, setting up Python, installing dependencies, linting, and running tests. These tasks only require `contents: read` permission, as no write operations are performed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
