### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -19,6 +19,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       digests: ${{ steps.hash.outputs.digests }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/jonaslejon/ct-monitor/security/code-scanning/2](https://github.com/jonaslejon/ct-monitor/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block to the `build` job. This block should limit the `GITHUB_TOKEN` permissions to the minimum required for the job. Since the `build` job does not interact with the repository (e.g., no pull requests, issues, or content modifications), the `contents: read` permission is sufficient.

The changes will be made to the `.github/workflows/generator-generic-ossf-slsa3-publish.yml` file. Specifically, the `permissions` block will be added under the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
